### PR TITLE
Fix mouse wheel zoom affecting tilemap when modal editors are open

### DIFF
--- a/crates/bevy_map_editor/src/tools/mod.rs
+++ b/crates/bevy_map_editor/src/tools/mod.rs
@@ -791,9 +791,17 @@ fn handle_zoom_input(
         false
     };
 
+    // Check if any modal editors are open (mirrors viewport input handling)
+    let modal_editor_open = editor_state.show_schema_editor
+        || editor_state.show_tileset_editor
+        || editor_state.show_spritesheet_editor
+        || editor_state.show_animation_editor
+        || editor_state.show_dialogue_editor
+        || editor_state.show_settings_dialog;
+
     for event in scroll_events.read() {
-        // Skip zoom if egui is actively using pointer or cursor is over side panels
-        if egui_using_pointer || over_side_panel {
+        // Skip zoom if egui is using pointer, cursor is over side panels, or modal editors are open
+        if egui_using_pointer || over_side_panel || modal_editor_open {
             continue;
         }
         let zoom_delta = event.y * 0.1;


### PR DESCRIPTION
## Summary

- Fixed an issue where mouse wheel zoom was affecting the tilemap even when modal UI windows (Schema Editor, Tileset Editor, Spritesheet Editor, Animation Editor, Dialogue Editor, Settings Dialog) were open
- Added a `modal_editor_open` check in `handle_zoom_input()` that mirrors the viewport input handling pattern

## Changes

Modified `crates/bevy_map_editor/src/tools/mod.rs`:
- Added check for all modal editor state flags before processing scroll events for zoom
- This prevents unintended tilemap zoom when users scroll within modal editor windows

## Test Plan

- [x] Open any modal editor (Schema Editor, Tileset Editor, etc.)
- [x] Try to use the mouse wheel to scroll within the modal
- [x] Verify the tilemap does not zoom while the modal is open
- [x] Close the modal and verify normal zoom behavior works