### PR TITLE
Changed launch to use `hot_reload` feature instead of `dev`, to be more descriptive

### DIFF
--- a/crates/bevy_map_editor/src/game_runner.rs
+++ b/crates/bevy_map_editor/src/game_runner.rs
@@ -130,7 +130,7 @@ pub struct LaunchOptions {
     pub project_path: PathBuf,
     /// Whether to use release mode
     pub release: bool,
-    /// Whether to enable hot-reload (adds 'dev' feature)
+    /// Whether to enable hot-reload (adds 'hot_reload' feature)
     pub hot_reload: bool,
 }
 
@@ -164,7 +164,7 @@ impl LaunchResult {
 ///
 /// Runs `cargo run` in the game project directory with optional flags:
 /// - `--release` if release mode is enabled
-/// - `--features dev` if hot-reload is enabled
+/// - `--features hot_reload` if hot-reload is enabled
 pub fn launch_game(options: &LaunchOptions) -> LaunchResult {
     // Verify project exists
     if !options.project_path.exists() {
@@ -438,7 +438,7 @@ fn run_build_thread(options: LaunchOptions, tx: Sender<BuildOutput>, cancel_rx: 
     }
 
     if options.hot_reload {
-        cmd.args(["--features", "dev"]);
+        cmd.args(["--features", "hot_reload"]);
     }
 
     // Force cargo to show progress even when piped


### PR DESCRIPTION
Currently when launching a new project that doesn't have a `dev` feature while using hot reload it spits out this error

```
error: the package '<name>' does not contain this feature: dev
```

Which isn't descriptive of the actual issue, or what bevy map editor expects you to do to fix it. Even as someone who is familiar with bevy it caught me off guard and I had to poke through the source code to figure out what had gone wrong.

While not a perfect fix, changing it to `hot_reload` makes it clearer what's gone wrong, what bevy map editor expects you to do and hints at how to fix it.