### PR TITLE
fix: Relativize paths in examples/**/*.map.json

### DIFF
--- a/examples/assets/maps/example_project.map.json
+++ b/examples/assets/maps/example_project.map.json
@@ -250,7 +250,7 @@
         {
           "id": "d9d8deb0-b39d-47df-9f11-a0bfe40fdaa4",
           "name": "Main",
-          "path": "C:/Dev/Workspace/bevy_map_editor/examples/assets/tiles/TilesetFloor.png",
+          "path": "tiles/TilesetFloor.png",
           "columns": 22,
           "rows": 26
         }
@@ -294,7 +294,7 @@
           }
         }
       },
-      "path": "C:/Dev/Workspace/bevy_map_editor/examples/assets/tiles/TilesetFloor.png",
+      "path": "tiles/TilesetFloor.png",
       "columns": 22,
       "rows": 26
     },
@@ -306,7 +306,7 @@
         {
           "id": "6f64d3d9-2795-4976-a689-e51367c9f913",
           "name": "Main",
-          "path": "C:/Dev/Workspace/bevy_map_editor/examples/assets/tiles/TilesetNature.png",
+          "path": "tiles/TilesetNature.png",
           "columns": 24,
           "rows": 21
         }
@@ -378,7 +378,7 @@
           "grid_height": 2
         }
       },
-      "path": "C:/Dev/Workspace/bevy_map_editor/examples/assets/tiles/TilesetNature.png",
+      "path": "tiles/TilesetNature.png",
       "columns": 24,
       "rows": 21
     }

--- a/examples/assets/maps/platformer_example.map.json
+++ b/examples/assets/maps/platformer_example.map.json
@@ -29,7 +29,7 @@
         {
           "id": "d7c5fd7b-989f-4f05-a0a0-b01ebefa1acc",
           "name": "Main",
-          "path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\assets\\platformer_assets\\sprites\\platforms.png",
+          "path": "platformer_assets/sprites/platforms.png",
           "columns": 4,
           "rows": 4
         }
@@ -73,7 +73,7 @@
           }
         }
       },
-      "path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\assets\\platformer_assets\\sprites\\platforms.png",
+      "path": "platformer_assets/sprites/platforms.png",
       "columns": 4,
       "rows": 4
     },
@@ -85,7 +85,7 @@
         {
           "id": "063e81f7-ce7e-4cdc-bff1-18ff92422b10",
           "name": "Main",
-          "path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\assets\\platformer_assets\\sprites\\world_tileset.png",
+          "path": "platformer_assets/sprites/world_tileset.png",
           "columns": 16,
           "rows": 16
         }
@@ -105,7 +105,7 @@
           "grid_height": 0
         }
       },
-      "path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\assets\\platformer_assets\\sprites\\world_tileset.png",
+      "path": "platformer_assets/sprites/world_tileset.png",
       "columns": 16,
       "rows": 16
     }
@@ -7717,7 +7717,7 @@
                   "triggers": []
                 }
               },
-              "sheet_path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\assets\\platformer_assets\\sprites\\knight.png",
+              "sheet_path": "platformer_assets/sprites/knight.png",
               "name": "player_sheet",
               "frame_height": 32,
               "frame_width": 32,
@@ -7740,7 +7740,7 @@
     {
       "id": "181c2ab6-a6bf-4429-9a8f-2b306708ee55",
       "name": "player_sheet",
-      "sheet_path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\assets\\platformer_assets\\sprites\\knight.png",
+      "sheet_path": "platformer_assets/sprites/knight.png",
       "frame_width": 32,
       "frame_height": 32,
       "columns": 8,
@@ -7796,7 +7796,7 @@
   },
   "stamps": [],
   "game_config": {
-    "project_path": "C:\\Dev\\Workspace\\map_editor_test\\platformer_example",
+    "project_path": "examples/platformer_example",
     "starting_level": "cccb7a74-fac8-4062-a2be-901e87a5352f",
     "project_name": "platformer_example",
     "use_release_build": false,

--- a/examples/platformer_example/assets/maps/platformer_example.map.json
+++ b/examples/platformer_example/assets/maps/platformer_example.map.json
@@ -29,7 +29,7 @@
         {
           "id": "d7c5fd7b-989f-4f05-a0a0-b01ebefa1acc",
           "name": "Main",
-          "path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\assets\\platformer_assets\\sprites\\platforms.png",
+          "path": "platformer_assets/sprites/platforms.png",
           "columns": 4,
           "rows": 4
         }
@@ -73,7 +73,7 @@
           }
         }
       },
-      "path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\assets\\platformer_assets\\sprites\\platforms.png",
+      "path": "platformer_assets/sprites/platforms.png",
       "columns": 4,
       "rows": 4
     },
@@ -85,7 +85,7 @@
         {
           "id": "063e81f7-ce7e-4cdc-bff1-18ff92422b10",
           "name": "Main",
-          "path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\assets\\platformer_assets\\sprites\\world_tileset.png",
+          "path": "platformer_assets/sprites/world_tileset.png",
           "columns": 16,
           "rows": 16
         }
@@ -105,7 +105,7 @@
           "grid_height": 0
         }
       },
-      "path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\assets\\platformer_assets\\sprites\\world_tileset.png",
+      "path": "platformer_assets/sprites/world_tileset.png",
       "columns": 16,
       "rows": 16
     }
@@ -7717,7 +7717,7 @@
                   "triggers": []
                 }
               },
-              "sheet_path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\assets\\platformer_assets\\sprites\\knight.png",
+              "sheet_path": "platformer_assets/sprites/knight.png",
               "name": "player_sheet",
               "frame_height": 32,
               "frame_width": 32,
@@ -7740,7 +7740,7 @@
     {
       "id": "181c2ab6-a6bf-4429-9a8f-2b306708ee55",
       "name": "player_sheet",
-      "sheet_path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\assets\\platformer_assets\\sprites\\knight.png",
+      "sheet_path": "platformer_assets/sprites/knight.png",
       "frame_width": 32,
       "frame_height": 32,
       "columns": 8,
@@ -7796,7 +7796,7 @@
   },
   "stamps": [],
   "game_config": {
-    "project_path": "C:\\Dev\\Workspace\\bevy_map_editor\\examples\\platformer_example",
+  "project_path": "examples/platformer_example",
     "starting_level": "cccb7a74-fac8-4062-a2be-901e87a5352f",
     "project_name": "platformer_example",
     "use_release_build": false,


### PR DESCRIPTION
Closes:
- #43 

Manually changed the *.map.json files, replacing absolute file paths with assets-path-relative paths to the same files. Also changed all `\\` to `/` in paths. 

# Testing
Passes all PR checks:
```
cargo fmt --all
cargo clippy --workspace -- -D warnings
cargo test --workspace
```

`cargo run --example collision_demo` works correctly on macOS 26.3.1 (Apple M2), and Windows 11 (aarch64).

# Notes

This only edits the `*.map.json` files in the `examples/` folder, there are no code changes. Creating a new project using the editor still writes absolute paths into the `.map.json` file for the project. I'd prefer to address that in a separate PR, possibly using [diff_paths](https://docs.rs/pathdiff/latest/pathdiff/fn.diff_paths.html) to handle creating relative paths to files outside of the assets folder.